### PR TITLE
Add Dockerfile and usage instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official Python 3.8 image as the base image
+FROM python:3.8
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the requirements.txt file into the container
+COPY requirements.txt /app/requirements.txt
+
+# Install the dependencies using pip install -r requirements.txt
+RUN pip install -r requirements.txt
+
+# Copy the rest of the application code into the container
+COPY . /app
+
+# Set the default command to run the Flask application
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "main:app"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ Submeta um arquivo **VCF** através da interface web. O sistema processará os d
 
 As APIs REST do dbSNP, ClinVar e Ensembl possuem um limite de até 30 requisições por solicitação. Por isso, a aplicação pode apresentar instabilidade ou lentidão em alguns momentos. Além disso, os servidores dessas plataformas ocasionalmente podem ficar instáveis ou não responder adequadamente às requisições. Nesses casos, o manual das APIs recomenda a resubmissão dos dados para completar o processo de anotação.
 
+## Usando o Dockerfile
+
+### Construindo a imagem Docker
+
+Para construir a imagem Docker, execute o seguinte comando no diretório raiz do projeto:
+
+```bash
+docker build -t getvar_app .
+```
+
+### Executando o contêiner Docker
+
+Para executar o contêiner Docker, use o seguinte comando:
+
+```bash
+docker run -p 5000:5000 getvar_app
+```
+
+Isso iniciará a aplicação Flask dentro de um contêiner Docker e a tornará acessível em `http://localhost:5000`.
+
 ## Licença
 
 Este projeto está licenciado sob a [Licença MIT](https://opensource.org/licenses/MIT). Consulte o arquivo LICENSE para mais informações.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 pysam
 aiohttp
 pytest
+gunicorn


### PR DESCRIPTION
Add Dockerfile and update README.md for Docker usage

* **Dockerfile**
  - Create a new `Dockerfile` in the root directory
  - Use the official Python 3.8 image as the base image
  - Set the working directory to `/app`
  - Copy the `requirements.txt` file into the container
  - Install the dependencies using `pip install -r requirements.txt`
  - Copy the rest of the application code into the container
  - Set the default command to run the Flask application

* **requirements.txt**
  - Add `gunicorn` to the list of dependencies

* **README.md**
  - Add a section on how to use the Dockerfile
  - Include instructions on building the Docker image
  - Include instructions on running the Docker container

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/madsondeluna/getvar_test/pull/2?shareId=8d8d15d3-ede2-4227-8500-55cf9bc3c30d).